### PR TITLE
ResponsiveButton param carry over issue

### DIFF
--- a/adminclient/src/components/ResponsiveButton/index.js
+++ b/adminclient/src/components/ResponsiveButton/index.js
@@ -19,7 +19,6 @@ class ResponsiveButton extends Component {
   //   super(props);
   // }
   getButtonLink(baseurl, params, prop) {
-    // console.debug({ baseurl, params, prop });
     let returnLink = baseurl;
     try {
       if (params && params.length > 0) {
@@ -55,7 +54,6 @@ class ResponsiveButton extends Component {
     let onclickProp = (clickBaseUrl)
       ? this.getButtonLink(clickBaseUrl, clickLinkParams, linkSelectionProp)
       : clickPassProps;
-    
     if (typeof clickprop === 'string' && clickprop.indexOf('func:this.props.reduxRouter') !== -1) { 
       onclickFunction = this.props.reduxRouter[ clickprop.replace('func:this.props.reduxRouter.', '') ];
     } else if (typeof clickprop === 'string' && clickprop.indexOf('func:this.funcs') !== -1) { 
@@ -67,11 +65,6 @@ class ResponsiveButton extends Component {
       onclickFunction = this.props[ clickprop.replace('func:this.props.', '') ];
     } else if (typeof clickprop === 'function') {
       onclickFunction = clickprop;
-    }
-    // onclickFunction = onclickFunction.bind(this);
-    if(typeof clickprop === 'string' && clickprop === 'func:this.props.createModal'){
-      onclickProp.pathname = (onclickProp.params)? this.getButtonLink(onclickProp.pathname, onclickProp.params, linkSelectionProp)
-      : onclickProp.pathname;
     }
     if (this.props.confirmModal) {
       return this.props.createModal(Object.assign({
@@ -130,6 +123,10 @@ class ResponsiveButton extends Component {
           ],
         },
       }, this.props.confirmModal));
+    } else if (typeof clickprop === 'string' && clickprop === 'func:this.props.createModal') {
+      let modalPathName = (onclickProp.params)? this.getButtonLink(onclickProp.pathname, onclickProp.params, linkSelectionProp)
+      : onclickProp.pathname;
+      return onclickFunction.call(this, {pathname: modalPathName }, clickFetchProps, clickSuccessProps);
     } else {
       // console.debug('debugging this regular onclick', this);
       return onclickFunction.call(this, onclickProp, clickFetchProps, clickSuccessProps);

--- a/views/test2/test_on_click.manifest.js
+++ b/views/test2/test_on_click.manifest.js
@@ -138,8 +138,8 @@ module.exports = {
                               onclickProps: {
                                 title: 'Edit Condition',
                                 pathname: `/r-admin/modals/testparams/:id`,
+                                params: [{ key: ':id', val: 'email' }],
                                 // someprops: 'some test prop'
-                                params: [{key: ':id', val: 'email'}]
                               },
                             },
                           }]
@@ -164,8 +164,7 @@ module.exports = {
           }]
         }]
       },
-      "resources": {
-      },
+      "resources": {},
       "onFinish": "render",
       "pageData": {
         "title": "Home",


### PR DESCRIPTION
Solved the issue where parameters for modal's path was getting overwritten by the first request that is made. Instead of updating the existing pathname property on the onclickProp object, new object containing the pathname is created each time a new modal is created.